### PR TITLE
Implement simple on-demand ssh proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,76 @@
 # strong-tunnel
 
 Easy tunnelling over ssh2.
+
+## Usage
+
+There is nothing to configure, but some environment variables are required.
+
+```
+var st = require('strong-tunnel');
+
+st(someUrl, function(err, url) {
+  // if someUrl was plain http, url will be someUrl
+  // if someUrl was http+ssh://, url points to a local ephemeral tunnel
+  http.get(url, onResponse);
+});
+```
+
+### Username
+
+Your current local username is assumed to be the username used for ssh. To
+override this you can set the `LOGNAME` environment variable to the desired
+username before the tunnel URL is created.
+
+### Credentials
+
+To keep the API simple, it is assumed that an ssh agent is already running,
+that the path to its domain socket is in the `SSH_AUTH_SOCK` environment
+variable, and that an appropriate private key has been loaded into that agent.
+
+This is usually done for you in modern \*nix environments as part of your
+login shell/session. See
+[ssh-agent(1)](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man1/ssh-agent.1)
+for more information about ssh agents.
+
+### Longer Example
+
+```js
+var fmt = require('util').format;
+var http = require('http');
+var st = require('strong-tunnel');
+
+var server = http.createServer(function(req, res) {
+  res.end(JSON.stringify(req.headers));
+});
+
+server.listen(3030, function() {
+  var direct = 'http://127.0.0.1:3030/';
+  var tunneled = 'http+ssh://127.0.0.1:3030/';
+
+  // Standard request using URL string
+  http.get(direct, resLog('%s using %s:', direct, direct));
+
+  // URL is only modified if a tunnelling URL was given
+  st(direct, function(err, url) {
+    // url == direct, unmodified
+    http.get(url, resLog('%s using %s:', direct, url));
+  });
+
+  st(tunneled, function(err, url) {
+    // url != tunneled, is modified
+    http.get(url, resLog('%s using %s:', tunneled, url));
+  });
+
+  server.unref();
+});
+
+function resLog(prefix) {
+  prefix = fmt.apply(null, arguments);
+  return function onResponse(res) {
+    res.on('data', function(d) {
+      console.log('%s -> %s', prefix, d);
+    });
+  };
+}
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,28 @@
+var tunnel = require('./lib/tunnel');
+var urlFmt = require('url').format;
+var urlParse = require('url').parse;
+
+module.exports = fromUrl;
+
+function fromUrl(url, callback) {
+  var str = JSON.parse(JSON.stringify(url));
+  var obj = str;
+
+  if (typeof str === 'object') {
+    str = urlFmt(str);
+  } else if (typeof obj === 'string') {
+    obj = urlParse(obj);
+  }
+
+  if (/\+ssh:$/.test(obj.protocol)) {
+    obj.protocol = obj.protocol.replace(/\+ssh:$/, ':');
+    // we've replaced the port, so delete host so URL is recomposed using
+    // $hostname:$port for $host
+    delete obj.host;
+    tunnel(obj, function(err, urlObj) {
+      callback(err, urlFmt(urlObj));
+    });
+  } else {
+    setImmediate(callback, null, url);
+  }
+}

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -1,0 +1,59 @@
+var net = require('net');
+var ssh2 = require('ssh2');
+
+module.exports = makeTunnel;
+
+function makeTunnel(urlObj, callback) {
+  var conn = new ssh2.Client();
+  var env = process.env;
+  var username = env.LOGNAME || env.USER || env.LNAME || env.USERNAME;
+
+  conn.on('ready', function() {
+    makeProxy(conn, urlObj, callback);
+    // don't keep the process alive if all we have is this connection
+    conn._sock.unref();
+  }).on('error', function(err) {
+    console.error('ssh connection error: ', err);
+  }).connect({
+    // extract hostname from url
+    host: urlObj.hostname,
+    // assume ssh is on port 22, not configurable (yet?)
+    port: 22,
+    // assume ssh user is the same as current user
+    username: username,
+    // assume an ssh agent is already running
+    agent: process.env.SSH_AUTH_SOCK,
+  });
+}
+
+function makeProxy(conn, urlObj, callback) {
+  var lAddr = '127.0.0.1';
+  // connect to remote localhost from the remote host
+  var rAddr = '127.0.0.1';
+  // don't conflict with anything
+  var lPort = 0;
+  // use the port from the input URL
+  var rPort = urlObj.port;
+
+  var server = net.createServer(function(c) {
+    conn.forwardOut(lAddr, lPort, rAddr, rPort, function(err, stream) {
+      stream.pipe(c).pipe(stream);
+      c.on('error', console.error.bind('proxy request error: '));
+      stream.on('error', console.error.bind('ssh stream error: '));
+    });
+  });
+
+  // listen on an ephemeral port and modify the input URL to connect to us
+  // instead of the original target
+  server.listen(0, function() {
+    // compose URL for connecting to this little TCP proxy server
+    urlObj.port = server.address().port;
+    urlObj.hostname = '127.0.0.1';
+    callback(null, urlObj);
+  });
+
+  server.on('error', console.error.bind('proxy server error: '));
+
+  // don't let this server keep the process alive
+  server.unref();
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/strongloop/strong-tunnel",
   "devDependencies": {
-    "tap": "^0.6.1"
+    "tap": "^0.6.0"
   },
   "dependencies": {
     "ssh2": "^0.4.4"

--- a/test/test-example.js
+++ b/test/test-example.js
@@ -1,0 +1,37 @@
+var fmt = require('util').format;
+var http = require('http');
+var st = require('../');
+
+var server = http.createServer(function(req, res) {
+  res.end(JSON.stringify(req.headers));
+});
+
+server.listen(3030, function() {
+  var direct = 'http://127.0.0.1:3030/';
+  var tunneled = 'http+ssh://127.0.0.1:3030/';
+
+  // Standard request using URL string
+  http.get(direct, resLog('%s using %s:', direct, direct));
+
+  // URL is only modified if a tunnelling URL was given
+  st(direct, function(err, url) {
+    // url == direct, unmodified
+    http.get(url, resLog('%s using %s:', direct, url));
+  });
+
+  st(tunneled, function(err, url) {
+    // url != tunneled, is modified
+    http.get(url, resLog('%s using %s:', tunneled, url));
+  });
+
+  server.unref();
+});
+
+function resLog(prefix) {
+  prefix = fmt.apply(null, arguments);
+  return function onResponse(res) {
+    res.on('data', function(d) {
+      console.log('%s -> %s', prefix, d);
+    });
+  };
+}

--- a/test/test-http-noop.js
+++ b/test/test-http-noop.js
@@ -1,0 +1,38 @@
+var fmt = require('util').format;
+var http = require('http');
+var st = require('../');
+var tap = require('tap');
+
+tap.test('connects to local http server over ssh', function(t) {
+
+  t.plan(6);
+
+  var server = http.createServer(function(req, res) {
+    t.ok(req, 'got a request');
+    res.end(JSON.stringify(process.versions));
+    server.unref();
+  });
+
+  server.listen(0, function() {
+    var direct = fmt('http://127.0.0.1:%d/', server.address().port);
+
+    t.ok(server.address(), 'test http server listening');
+
+    st(direct, function(err, url) {
+      t.ifError(err, 'strong-tunnel should not error on url ' + direct);
+      t.equal(url, direct);
+      assertRequest(url);
+    });
+  });
+
+  function assertRequest(url) {
+    t.assert(url, 'url: ' + url);
+    http.get(url, function(res) {
+      res.on('data', function(d) {
+        t.ok(d, 'received response');
+      });
+    }).on('error', function(err) {
+      t.ifError(err);
+    });
+  }
+});

--- a/test/test-http.js
+++ b/test/test-http.js
@@ -1,0 +1,46 @@
+var fmt = require('util').format;
+var http = require('http');
+var st = require('../');
+var tap = require('tap');
+
+tap.test('connects to local http server over ssh', function(t) {
+
+  t.plan(9);
+
+  var env = process.env;
+  var username = env.LOGNAME || env.USER || env.LNAME || env.USERNAME;
+  t.assert(username, 'there is a username');
+
+  t.assert(env.SSH_AUTH_SOCK, 'there is an ssh agent socket open');
+
+  var server = http.createServer(function(req, res) {
+    t.ok(req, 'got a request');
+    res.end(JSON.stringify(process.versions));
+  });
+
+  server.listen(0, function() {
+    var direct = fmt('http://127.0.0.1:%d/', server.address().port);
+    var tunneled = fmt('http+ssh://127.0.0.1:%d/', server.address().port);
+
+    t.ok(server.address(), 'test http server listening');
+
+    st(tunneled, function(err, url) {
+      t.ifError(err, 'strong-tunnel should not error on url ' + tunneled);
+      t.notEqual(url, direct);
+      t.notEqual(url, tunneled);
+      assertRequest(url);
+    });
+  });
+
+  function assertRequest(url) {
+    t.assert(url, 'url: ' + url);
+    http.get(url, function(res) {
+      res.on('data', function(d) {
+        t.ok(d, 'received response');
+        server.close();
+      });
+    }).on('error', function(err) {
+      t.ifError(err);
+    });
+  }
+});

--- a/test/test-noop.js
+++ b/test/test-noop.js
@@ -1,0 +1,22 @@
+var st = require('../');
+var tap = require('tap');
+
+var httpUrl = 'http://foo.com/';
+var tcpUrl = 'tcp://foo.com:1234/';
+var fileUrl = 'file:///some/path';
+
+tap.test('no-op behaviours', function(t) {
+  t.plan(6);
+  st(httpUrl, function(err, url) {
+    t.ifError(err, 'should not error with url: ' + url);
+    t.equal(url, httpUrl);
+  });
+  st(tcpUrl, function(err, url) {
+    t.ifError(err, 'should not error with url: ' + url);
+    t.equal(url, tcpUrl);
+  });
+  st(fileUrl, function(err, url) {
+    t.ifError(err, 'should not error with url: ' + url);
+    t.equal(url, fileUrl);
+  });
+});

--- a/test/test-surface.js
+++ b/test/test-surface.js
@@ -1,0 +1,8 @@
+var tap = require('tap');
+
+tap.test('exported methods', function(t) {
+  var st = require('../');
+  t.type(st, 'function', 'url is exported as a function');
+  t.equal(st.length, 2, 'url expects a single argument');
+  t.end();
+});


### PR DESCRIPTION
Nothing is configurable and the following assumptions are made:
- current username is the same as remote username
- there is an active ssh agent that can provide any auth we need
- ssh is always on port 22

Connected to strongloop/strong-pm#98
