### PR TITLE
Add support for ssh options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ Easy tunnelling over ssh2.
 
 ## Usage
 
-There is nothing to configure, but some environment variables are required.
+There is nothing to configure, but some environment variables are used to
+set defaults if no options are given.
 
 ```
 var st = require('strong-tunnel');
 
-st(someUrl, function(err, url) {
+st(someUrl, sshOpts, function(err, url) {
   // if someUrl was plain http, url will be someUrl
   // if someUrl was http+ssh://, url points to a local ephemeral tunnel
+  // sshOpts is optional with defaults described below.
   http.get(url, onResponse);
 });
 ```
@@ -44,6 +46,10 @@ var server = http.createServer(function(req, res) {
   res.end(JSON.stringify(req.headers));
 });
 
+var sshOpts = {
+  host: '127.0.0.1',
+};
+
 server.listen(3030, function() {
   var direct = 'http://127.0.0.1:3030/';
   var tunneled = 'http+ssh://127.0.0.1:3030/';
@@ -57,7 +63,8 @@ server.listen(3030, function() {
     http.get(url, resLog('%s using %s:', direct, url));
   });
 
-  st(tunneled, function(err, url) {
+  // optional second argument containing ssh config
+  st(tunneled, sshOpts, function(err, url) {
     // url != tunneled, is modified
     http.get(url, resLog('%s using %s:', tunneled, url));
   });

--- a/index.js
+++ b/index.js
@@ -4,7 +4,13 @@ var urlParse = require('url').parse;
 
 module.exports = fromUrl;
 
-function fromUrl(url, callback) {
+function fromUrl(url, opts, callback) {
+  if (callback === undefined && typeof opts === 'function') {
+    callback = opts;
+    opts = {};
+  }
+  opts = opts || {};
+
   var str = JSON.parse(JSON.stringify(url));
   var obj = str;
 
@@ -19,7 +25,7 @@ function fromUrl(url, callback) {
     // we've replaced the port, so delete host so URL is recomposed using
     // $hostname:$port for $host
     delete obj.host;
-    tunnel(obj, function(err, urlObj) {
+    tunnel(obj, opts, function(err, urlObj) {
       callback(err, urlFmt(urlObj));
     });
   } else {

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -3,10 +3,24 @@ var ssh2 = require('ssh2');
 
 module.exports = makeTunnel;
 
-function makeTunnel(urlObj, callback) {
+function makeTunnel(urlObj, opts, callback) {
   var conn = new ssh2.Client();
   var env = process.env;
   var username = env.LOGNAME || env.USER || env.LNAME || env.USERNAME;
+
+  // extract hostname from url
+  opts.host = opts.host || urlObj.hostname;
+
+  // assume ssh is on port 22
+  opts.port = opts.port || 22;
+
+  // assume ssh user is the same as current user if not specified
+  opts.username = opts.username || env.SSH_USER || env.LOGNAME || env.USER || env.LNAME || env.USERNAME;
+
+  // assume ssh agent if no other auth given
+  if (!opts.password || !opts.privateKey) {
+    opts.agent = opts.agent || process.env.SSH_AUTH_SOCK;
+  }
 
   conn.on('ready', function() {
     makeProxy(conn, urlObj, callback);
@@ -14,16 +28,7 @@ function makeTunnel(urlObj, callback) {
     conn._sock.unref();
   }).on('error', function(err) {
     console.error('ssh connection error: ', err);
-  }).connect({
-    // extract hostname from url
-    host: urlObj.hostname,
-    // assume ssh is on port 22, not configurable (yet?)
-    port: 22,
-    // assume ssh user is the same as current user
-    username: username,
-    // assume an ssh agent is already running
-    agent: process.env.SSH_AUTH_SOCK,
-  });
+  }).connect(opts);
 }
 
 function makeProxy(conn, urlObj, callback) {
@@ -37,6 +42,9 @@ function makeProxy(conn, urlObj, callback) {
 
   var server = net.createServer(function(c) {
     conn.forwardOut(lAddr, lPort, rAddr, rPort, function(err, stream) {
+      if (err) {
+        throw err;
+      }
       stream.pipe(c).pipe(stream);
       c.on('error', console.error.bind('proxy request error: '));
       stream.on('error', console.error.bind('ssh stream error: '));

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/strongloop/strong-tunnel",
   "devDependencies": {
+    "buffer-equal-constant-time": "^1.0.1",
     "tap": "^0.6.0"
   },
   "dependencies": {

--- a/test/test-example.js
+++ b/test/test-example.js
@@ -6,6 +6,10 @@ var server = http.createServer(function(req, res) {
   res.end(JSON.stringify(req.headers));
 });
 
+var sshOpts = {
+  host: '127.0.0.1',
+};
+
 server.listen(3030, function() {
   var direct = 'http://127.0.0.1:3030/';
   var tunneled = 'http+ssh://127.0.0.1:3030/';
@@ -19,7 +23,8 @@ server.listen(3030, function() {
     http.get(url, resLog('%s using %s:', direct, url));
   });
 
-  st(tunneled, function(err, url) {
+  // optional second argument containing ssh config
+  st(tunneled, sshOpts, function(err, url) {
     // url != tunneled, is modified
     http.get(url, resLog('%s using %s:', tunneled, url));
   });

--- a/test/test-noop.js
+++ b/test/test-noop.js
@@ -6,7 +6,7 @@ var tcpUrl = 'tcp://foo.com:1234/';
 var fileUrl = 'file:///some/path';
 
 tap.test('no-op behaviours', function(t) {
-  t.plan(6);
+  t.plan(12);
   st(httpUrl, function(err, url) {
     t.ifError(err, 'should not error with url: ' + url);
     t.equal(url, httpUrl);
@@ -16,6 +16,18 @@ tap.test('no-op behaviours', function(t) {
     t.equal(url, tcpUrl);
   });
   st(fileUrl, function(err, url) {
+    t.ifError(err, 'should not error with url: ' + url);
+    t.equal(url, fileUrl);
+  });
+  st(httpUrl, {}, function(err, url) {
+    t.ifError(err, 'should not error with url: ' + url);
+    t.equal(url, httpUrl);
+  });
+  st(tcpUrl, {}, function(err, url) {
+    t.ifError(err, 'should not error with url: ' + url);
+    t.equal(url, tcpUrl);
+  });
+  st(fileUrl, {}, function(err, url) {
     t.ifError(err, 'should not error with url: ' + url);
     t.equal(url, fileUrl);
   });

--- a/test/test-surface.js
+++ b/test/test-surface.js
@@ -3,6 +3,6 @@ var tap = require('tap');
 tap.test('exported methods', function(t) {
   var st = require('../');
   t.type(st, 'function', 'url is exported as a function');
-  t.equal(st.length, 2, 'url expects a single argument');
+  t.equal(st.length, 3, 'url expects a single argument');
   t.end();
 });


### PR DESCRIPTION
Makes strong-tunnel configurable while retaining the existing defaults and a backwards compatible API.

Options are intentionally undocumented, but technically the options are just passed to ssh2 so they are the same as documented in https://www.npmjs.com/package/ssh2#client-methods

Required for strongloop/strong-pm#128 to support more reasonable username overrides.
